### PR TITLE
Pin pydantic to v1 for Cygwin install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "click>=8.0.0",
-    "pydantic>=2.0.0",
+    "pydantic>=1.10,<2.0",
     "rich>=13.0.0",
     "typing-extensions>=4.0.0; python_version<'3.10'",
     # Cygwin-compatible file watching

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=8.0.0
-pydantic>=2.0.0
+pydantic>=1.10,<2.0
 rich>=13.0.0
 typing-extensions>=4.0.0; python_version<"3.10"
 # Note: watchdog and psutil have issues on Cygwin


### PR DESCRIPTION
## Summary
- avoid maturin build failures on Cygwin by pinning pydantic to 1.x

## Testing
- `PYTHONPATH=src pytest -o addopts=` (fails: ImportError: cannot import name 'ConnectorConfig')

------
https://chatgpt.com/codex/tasks/task_b_68a56561677c83268bde42152f4070d1